### PR TITLE
Workaround compile error on MSVC2017 win10

### DIFF
--- a/Simulator/TritiumSimulatorWindow.cpp
+++ b/Simulator/TritiumSimulatorWindow.cpp
@@ -39,32 +39,39 @@ void TritiumSimulatorWindow::messageReceived(can_message_t cmsg)
     {
         //07 00 00 02 08 00 00 01
         //01 00 07 00 FA 00 05 00
-        if(memcmp(cmsg.data, (const uint8_t[]){0x01,0x00,0x07,0x00,0xFA,0x00,0x05,0x00}, 8) == 0)
+        const uint8_t msg1[] = {0x01,0x00,0x07,0x00,0xFA,0x00,0x05,0x00};
+        if(memcmp(cmsg.data, &msg1, 8) == 0)
         {
             can_message_t cmsg;
             cmsg.IDE = 0; cmsg.RTR = 0; cmsg.dlc = 8;
             cmsg.id = m_baseId + 0x12;
-            memcpy(cmsg.data, (const uint8_t[]){0x03,0x00,0x07,0x00,0xFA,0x00,0x05,0x00}, 8);
+            const uint8_t msg2[] = {0x03,0x00,0x07,0x00,0xFA,0x00,0x05,0x00};
+            memcpy(cmsg.data, &msg2, 8);
             m_canHandle->transmit(cmsg);
 
             cmsg.id = m_baseId + 0x14;
-            memcpy(cmsg.data, (const uint8_t[]){0x00,0x70,0x00,0x02,0x00,0x35,0x11,0x00}, 8);
+            const uint8_t msg3[] = {0x00,0x70,0x00,0x02,0x00,0x35,0x11,0x00};
+            memcpy(cmsg.data, &msg3, 8);
             m_canHandle->transmit(cmsg);
         }
-        if(memcmp(cmsg.data, (const uint8_t[]){0x04,0,0,0,0,0,0,0}, 8) == 0)
+        const uint8_t msg4[] = {0x04,0,0,0,0,0,0,0};
+        if(memcmp(cmsg.data, &msg4, 8) == 0)
         {
             can_message_t cmsg;
             cmsg.IDE = 0; cmsg.RTR = 0; cmsg.dlc = 8;
             cmsg.id = m_baseId + 0x14;
-            memcpy(cmsg.data, (const uint8_t[]){0x80,0,0,0,0,0,0,0}, 8);
+            const uint8_t msg5[] = {0x80,0,0,0,0,0,0,0};
+            memcpy(cmsg.data, &msg5, 8);
             m_canHandle->transmit(cmsg);
         }
-        if(memcmp(cmsg.data, (const uint8_t[]){0x02,0,0,0,0,0,0,0}, 8) == 0)
+        const uint8_t msg6[] = {0x02,0,0,0,0,0,0,0};
+        if(memcmp(cmsg.data, &msg6, 8) == 0)
         {
             can_message_t cmsg;
             cmsg.IDE = 0; cmsg.RTR = 0; cmsg.dlc = 8;
             cmsg.id = m_baseId + 0x12;
-            memcpy(cmsg.data, (const uint8_t[]){0x02,0,0x02,0,0,0,0,0}, 8);
+            const uint8_t msg7[] = {0x02,0,0x02,0,0,0,0,0};
+            memcpy(cmsg.data, &msg7, 8);
             m_canHandle->transmit(cmsg);
         }
     }


### PR DESCRIPTION
I was getting compile error when compiling for win10 with msvc2017

This where the changes I had to implement to get get around it.

Now I have tried this software on: Win10, Linux and macos 

All seem to work fine. Though I have not completely understood how to use this software yet.